### PR TITLE
Realizamos configuración básica para levantar Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,5 @@ flowchart TD
 
 - [Servidor gRPC](./grpc_server/README.md)
 - [Cliente gRPC](./grpc_client/README.md)
+
+⚙️ **Nota**: Para pruebas locales, el servidor gRPC puede interactuar con servicios auxiliares como MailHog, Kafka y Kafbat UI, los cuales se levantan vía Docker (ver [README Servidor gRPC](./grpc_server/README.md) para más detalles).

--- a/grpc_server/README.md
+++ b/grpc_server/README.md
@@ -113,17 +113,18 @@ Forma parte de la primera entrega del trabajo práctico de la materia Desarrollo
 
 1. Clonar el repositorio
 
-```bash
-git clone https://github.com/MaximilianoCalahorra/TP-Distribuidos-GrupoC-backend
-cd TP-Distribuidos-GrupoC-backend/grpc_server
-```
+    ```bash
+    git clone https://github.com/MaximilianoCalahorra/TP-Distribuidos-GrupoC-backend
+    cd TP-Distribuidos-GrupoC-backend/grpc_server
+    ```
 
 2. Cargar las variables de entorno para la base de datos MySQL en ```application.properties```:
-```bash
-spring.datasource.url=jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?createDatabaseIfNotExist=true
-spring.datasource.username=${DATABASE_USERNAME}
-spring.datasource.password=${DATABASE_PASSWORD}
-```
+
+    ```bash
+    spring.datasource.url=jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?createDatabaseIfNotExist=true
+    spring.datasource.username=${DATABASE_USERNAME}
+    spring.datasource.password=${DATABASE_PASSWORD}
+    ```
 
 3. Correr la clase ```TpSistemasDistribuidosGrupoCApplication.java``` para levantar el proyecto.
 
@@ -131,10 +132,33 @@ spring.datasource.password=${DATABASE_PASSWORD}
 
 5. Cargar el siguiente script en la base de datos para tener los roles y un presidente: [cargar_datos_iniciales.sql](https://github.com/MaximilianoCalahorra/TP-Distribuidos-GrupoC-backend/blob/master/cargar_datos_iniciales.sql)
 
-Las credenciales del presidente son:
+Las **credenciales del presidente** son:
 - nombreUsuario: j.perez
 - email: j.perez@empuje-comunitario.com
 - clave: IzsDXBLFqwPi
+
+---
+
+### 💻 **Servicios auxiliares (Docker)**
+
+Para ejecutar el servidor localmente y contar con los servicios de **MailHog, Kafka y Kafbat UI**:
+
+1. Asegurarse de tener Docker y Docker Compose instalados.
+
+2. Desde la carpeta ```grpc_server```, levantar los servicios:
+
+    ```bash
+    docker compose -p tp-sd-grupo-c-local up -d
+    ```
+
+    Esto levantará:
+    - ```MailHog```: SMTP + web (http://localhost:8025)
+    - ```Kafka Broker```: puerto 29092 para conectarse desde la app local
+    - ```Kafbat UI```: interfaz web para crear/consultar topics (http://localhost:9000)
+
+3. Con esto, el servidor gRPC puede conectarse a Kafka y enviar/recibir mensajes aunque se levante localmente, y los desarrolladores pueden usar Kafbat UI para simular mensajes desde otras ONGs.
+
+⚠️ **Nota**: MailHog, Kafka y Kafbat UI deben ejecutarse en Docker; el resto del servidor Spring Boot puede correr localmente sin problemas.
 
 ---
 

--- a/grpc_server/docker-compose.yml
+++ b/grpc_server/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  # ==========================================
+  # Kafka Broker (modo KRaft, sin Zookeeper)
+  # ==========================================
+  kafka:
+    image: apache/kafka:3.7.0
+    container_name: kafka-broker-local
+    restart: unless-stopped
+    ports:
+      - "9092:9092"     # puerto del broker para otros contenedores
+      - "29092:29092"   # puerto para conectarse desde host/local
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka-data-local:/var/lib/kafka/data
+
+  # ==========================================
+  # Kafbat UI para administrar Kafka
+  # ==========================================
+  kafbat-ui:
+    image: ghcr.io/kafbat/kafka-ui:latest
+    container_name: kafbat-local
+    restart: unless-stopped
+    ports:
+      - "9000:8080" # puerto local para acceder a UI
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      - kafka
+
+  # ==========================================
+  # MailHog
+  # ==========================================
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog-local
+    restart: unless-stopped
+    ports:
+      - "1025:1025"  # puerto SMTP
+      - "8025:8025"  # interfaz web
+
+volumes:
+  kafka-data-local:

--- a/grpc_server/src/main/resources/application.properties
+++ b/grpc_server/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=TP_SistemasDistribuidos_GrupoC
-#DATABASE
+
+# DATABASE
 #--------------------------------------------------------------------------------------------------------------------------------
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?createDatabaseIfNotExist=true
@@ -13,7 +14,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 #--------------------------------------------------------------------------------------------------------------------------------
 
-#Java Email Sender
+# Java Email Sender
 #--------------------------------------------------------------------------------------------------------------------------------
 # Datos del servidor SMTP de Gmail
 spring.mail.host=${MAILHOG_URL:localhost}
@@ -26,12 +27,22 @@ spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=false
 #-----------------------------------------------------------------------------------------------------------------
 
-#GRPC
+# Kafka
+#-----------------------------------------------------------------------------------------------------------------
+kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:29092}
+kafka.client-id=${KAFKA_CLIENT_ID:tp-grupoc-client}
+kafka.consumer-group-id=${KAFKA_CONSUMER_GROUP_ID:tp-grupoc-group}
+kafka.auto-offset-reset=${KAFKA_AUTO_OFFSET_RESET:earliest}
+#-----------------------------------------------------------------------------------------------------------------
+
+# GRPC
+#-----------------------------------------------------------------------------------------------------------------
 grpc.server.port=9090
 logging.level.org.springframework.security=DEBUG
 logging.level.net.devh.boot.grpc=DEBUG
-
 #-----------------------------------------------------------------------------------------------------------------
 
-#CORS
+# CORS
+#-----------------------------------------------------------------------------------------------------------------
 cors.allowed.origin=${CORS_ALLOWED_ORIGIN:http://localhost:5173}
+#-----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Realizamos algunos ajustes sobre los readmes.
- Incorporamos un docker-compose.yml para levantar con Docker los servicios de MailHog, Kafka y Kafbat UI, de forma que el resto del sistema puedo consumirlos.
- Emprolijamos el application.properties y agregamos algunas variables relacionadas a Kafka